### PR TITLE
一部のフォントサイズと余白の修正/カードUIのぼかし

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -17,7 +17,7 @@ export default function About() {
                     <img src="/blockchain.png" className="card-img" />
                     <h2 className="card-title">ブロックチェーン × ○○</h2>
                     <p className="card-text">
-                        ブロックチェーン技術と、既存のテクノロジーを生かして、どのような事が実現できるのか、仮説をを通して検証いています。
+                        ブロックチェーン技術と、既存のテクノロジーを生かして、どのような事が実現できるのか、仮説を通して検証いています。
                     </p>
                     <div className="card-link">
                         <a className="card-btn">MORE</a>
@@ -85,6 +85,7 @@ export default function About() {
                     margin: 30px;
                     margin-bottom: 50px;
                     border-radius: 10px;
+                    box-shadow: 0 0px 20px rgba(0, 0, 0, 0.2);
                 }
 
                 .card-img {
@@ -97,6 +98,7 @@ export default function About() {
                     margin-top: 0.3em;
                     margin-bottom: 0.3em;
                     font-size: 32px;
+                    font-weight: bold;
                 }
 
                 .card-text {
@@ -153,6 +155,8 @@ export default function About() {
                         width: 85%;
                         height: 50%;
                         margin: 0 auto 30px;
+                        box-shadow: 0 7px 14px rgba(50, 50, 93, 0.1),
+                            0 3px 6px rgba(0, 0, 0, 0.08);
                     }
 
                     .card-img {
@@ -161,10 +165,13 @@ export default function About() {
 
                     .card-title {
                         font-size: 16px;
+
+                        margin-top: 0.3em;
+                        margin-bottom: 0.5em;
                     }
 
                     .card-text {
-                        font-size: 8px;
+                        font-size: 0.7em;
                     }
                 }
 

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -6,9 +6,12 @@ export default function Contact() {
             </h1>
             <div className="divider">
                 <div className="seminar_info">
-                    <p>所在地： 長野県長野市三輪107研究室</p>
-                    <p>メールアドレス： rika.kayatsu@19G054.u-nagano.ac.jp</p>
-                    <p>電話番号： 070-8518-5090</p>
+                    <p>所在地：</p>
+                    <p>長野県長野市三輪107研究室</p>
+                    <p>メールアドレス：</p>
+                    <p>rika.kayatsu@19G054.u-nagano.ac.jp</p>
+                    <p>電話番号：</p>
+                    <p>070-8518-5090</p>
                 </div>
                 <div className="link">
                     <a className="btn">お問い合わせフォームへ</a>
@@ -39,8 +42,11 @@ export default function Contact() {
 
                 p {
                     font-size: 24px;
-                    margin-bottom: 20px;
                     text-align: left;
+                }
+
+                p:nth-child(even) {
+                    margin-bottom: 20px;
                 }
 
                 span {
@@ -77,6 +83,7 @@ export default function Contact() {
                     .divider {
                         flex-direction: column;
                     }
+
                     h1 {
                         font-size: 32px;
                     }
@@ -89,8 +96,10 @@ export default function Contact() {
                         font-size: 0.5em;
                         padding-left: 1em;
                     }
+
                     .link {
-                        margin-top: 30px;
+                        margin-top: 0px;
+                        margin-bottom: 30px;
                     }
                 }
 

--- a/src/components/Member.jsx
+++ b/src/components/Member.jsx
@@ -53,16 +53,15 @@ export default function Member() {
                 .member-img {
                     display: block;
                     width: 500px;
-                    pointer-events: none;
-                    border-radius: 10px;
-                    padding-bottom: 30px;
+                    margin-bottom: 30px;
+                    box-shadow: 0 0px 3px rgba(0, 0, 0, 0.2);
                 }
 
                 .description {
                     flex: 1;
                     height: 400px;
                     background: #f4f5f7;
-                    padding-left: 100px;
+                    margin-left: 100px;
                 }
 
                 .link {
@@ -99,10 +98,6 @@ export default function Member() {
                         width: 90%;
                     }
 
-                    .description {
-                        padding-left: 0;
-                    }
-
                     h1 {
                         font-size: 32px;
                     }
@@ -114,10 +109,12 @@ export default function Member() {
 
                     .member-img {
                         width: 100%;
+                        border-radius: 10px;
+                        margin-bottom: 0px;
                     }
 
                     .description {
-                        padding-left: 0;
+                        margin-left: 0;
                     }
 
                     .link {

--- a/src/components/Post.jsx
+++ b/src/components/Post.jsx
@@ -112,12 +112,12 @@ export default function Post() {
                     .post-time-stamp {
                         padding-left: 10px;
                         padding-right: 30px;
-                        font-size: 8px;
+                        font-size: 0.6em;
                         display: block;
                     }
 
                     .post-title {
-                        font-size: 8px;
+                        font-size: 0.7em;
                     }
                 }
 

--- a/src/components/layouts/Header/styles.module.scss
+++ b/src/components/layouts/Header/styles.module.scss
@@ -64,7 +64,7 @@
     }
 
     .seminar {
-        font-size: 8px;
+        font-size: 0.7em;
         font-weight: bolder;
     }
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -75,6 +75,8 @@ export default function Home() {
 
                     .description {
                         font-size: 1rem;
+                        top: 15%;
+                        width: 250px;
                     }
                 }
             `}</style>


### PR DESCRIPTION
# 一部のフォントサイズと余白の修正
- ヘッダー、投稿、トップイメージ中の文字、カードUIの詳細部分などのフォントサイズを調整（emに変更）
- スマホレイアウト時に発生する余分な余白を除去

# カードUIのぼかし
- about部分のカードUIにぼかしを入れる
- member部分のイメージにも、若干のぼかしを入れる